### PR TITLE
Implemented Lazy open

### DIFF
--- a/ci/requirements/py3.10.yml
+++ b/ci/requirements/py3.10.yml
@@ -6,3 +6,4 @@ dependencies:
   - xarray
   - pillow
   - netcdf4
+  - dask

--- a/ci/requirements/py3.8.yml
+++ b/ci/requirements/py3.8.yml
@@ -6,3 +6,4 @@ dependencies:
   - xarray
   - pillow
   - netcdf4
+  - dask

--- a/ci/requirements/py3.9.yml
+++ b/ci/requirements/py3.9.yml
@@ -6,3 +6,4 @@ dependencies:
   - xarray
   - pillow
   - netcdf4
+  - dask

--- a/sif_parser/sif_open.py
+++ b/sif_parser/sif_open.py
@@ -94,14 +94,20 @@ def np_open(sif_file, ignore_corrupt=False, lazy=None):
     return data, info
 
 # --- xarray open ---
-def xr_open(sif_file, ignore_corrupt=False):
+def xr_open(sif_file, ignore_corrupt=False, lazy=None):
     """
     Read file and set into xr.DataArray.
     
     Parameters
     ----------
     sif_file: 
-    ignore_corrupt
+        path to the file
+    ignore_corrupt: 
+        True if ignore the corrupted frames.
+    lazy: either of None | 'dask'
+        None: load all the data into the memory
+        'dask': returns dask.Array that consists of np.memmap
+            This requires dask installed into the computer.
     """
     try:
         import xarray as xr
@@ -110,7 +116,10 @@ def xr_open(sif_file, ignore_corrupt=False):
             "xarray needs to be installed to use xr_open."
         )
 
-    data, info = np_open(sif_file, ignore_corrupt=ignore_corrupt)
+    if lazy == 'memmap':
+        raise ValueError(
+            "Memmap is not supported for `xr_open`.Use `lazy='dask'` instead.")
+    data, info = np_open(sif_file, ignore_corrupt=ignore_corrupt, lazy=lazy)
     # coordinates
     coords = OrderedDict()
     # extract time stamps

--- a/testings/test_open.py
+++ b/testings/test_open.py
@@ -43,6 +43,19 @@ def test_open(filename):
         assert np.allclose(ref, data)
 
 
+@pytest.mark.parametrize('filename', filenames)
+def test_dask_open(filename):
+    data, info = sif_parser.np_open(filename)
+    data_lazy, info = sif_parser.np_open(filename, lazy='dask')
+    assert np.allclose(data, data_lazy.compute())
+
+@pytest.mark.parametrize('filename', filenames)
+def test_memmap_open(filename):
+    data, info = sif_parser.np_open(filename)
+    data_lazy, info = sif_parser.np_open(filename, lazy='memmap')
+    assert np.allclose(data, data_lazy)
+
+
 def test_one_image():
     with open(PUBLIC_DATA_DIR + 'image.sif', 'rb') as f:
         tile, size, n_frames, info = _sif_open._open(f)

--- a/testings/test_open.py
+++ b/testings/test_open.py
@@ -49,10 +49,25 @@ def test_dask_open(filename):
     data_lazy, info = sif_parser.np_open(filename, lazy='dask')
     assert np.allclose(data, data_lazy.compute())
 
+    data_lazy, info = sif_parser.np_open(filename, lazy='dask')
+    size = sys.getsizeof(data_lazy)
+    size_compute = sys.getsizeof(data_lazy.compute())
+    assert size < size_compute 
+
+
+@pytest.mark.parametrize('filename', filenames)
+def test_xr_dask_open(filename):
+    data = sif_parser.xr_open(filename)
+    data_lazy = sif_parser.xr_open(filename, lazy='dask')
+    assert np.allclose(data, data_lazy.compute())
+
+
 @pytest.mark.parametrize('filename', filenames)
 def test_memmap_open(filename):
     data, info = sif_parser.np_open(filename)
     data_lazy, info = sif_parser.np_open(filename, lazy='memmap')
+    assert hasattr(data_lazy, 'filename')
+    assert not hasattr(data, 'filename')
     assert np.allclose(data, data_lazy)
 
 


### PR DESCRIPTION
According to #15 , I implemented the lazy open feature.
By using `lazy='memmap'` or `lazy='dask'`, we can index a certain region of the file without actually reading it.

```python
>>> data, info = sif_parser.np_open('./testings/public_testdata/issue13.sif', lazy='memmap')
>>> data.shape
 (1900, 74, 84)
>>> da = data[10]  
>>> np.array(da)  # <-- Read only the 10th frame and store it into the memory
```